### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ rustup.sh --revision=1.0.0-beta
 
 * GC old temp and cache files.
 * Error on unknown command line options.
+* Do cleanup of in-use temp files on trap.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ rustup.sh --revision=1.0.0-beta
 
 ## Future work
 
-* Store downloads with --save.
 * GC old temp and cache files.
 * Rustup doesn't need to store manifests like it does.
 * Error on unknown command line options.

--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ rustup.sh --revision=1.0.0-beta
 * GC old temp and cache files.
 * Error on unknown command line options.
 * Do cleanup of in-use temp files on trap.
+* Don't clobber multirust if it is installed at the destination prefix.

--- a/README.md
+++ b/README.md
@@ -64,5 +64,4 @@ rustup.sh --revision=1.0.0-beta
 ## Future work
 
 * GC old temp and cache files.
-* Rustup doesn't need to store manifests like it does.
 * Error on unknown command line options.

--- a/rustup.sh
+++ b/rustup.sh
@@ -21,10 +21,12 @@
 # Oh, my goodness, error handling. It's terrifying.
 #
 # This doesn't use -e because it makes it hard to control the
-# presentation of and response to errors. So most every command
-# needs to be followed with a check of `$?`. Commands that
-# should more-or-less never fail are either called via `ensure`,
-# or followed by a call to `need_ok`.
+# presentation of and response to errors.
+#
+# Pass errors on on: `run cmd arg1 arg2 || return 1`. `run` will run
+# the command, printing it if it fails; the `|| return 1` passes the
+# error on to the caller. `ensure cmd arg1 arg1`, runs the command,
+# printing it if it fails, and termining execution.
 #
 # Don't make typos. You just have to be better than that.
 #

--- a/rustup.sh
+++ b/rustup.sh
@@ -896,9 +896,18 @@ get_architecture() {
 
     # Detect 64-bit linux with 32-bit userland
     if [ $_ostype = unknown-linux-gnu -a $_cputype = x86_64 ]; then
-	file -L "$SHELL" | grep -q "x86[_-]64"
-	if [ $? != 0 ]; then
-	    local _cputype=i686
+	# $SHELL does not exist in standard 'sh', so probably only exists
+	# if configure is running in an interactive bash shell. /usr/bin/env
+	# exists *everywhere*.
+	local _bin_to_probe="$SHELL"
+	if [ -z "$_bin_to_probe" -a -e "/usr/bin/env" ]; then
+	    _bin_to_probe="/usr/bin/env"
+	fi
+	if [ -n "$_bin_to_probe" ]; then
+	    file -L "$_bin_to_probe" | grep -q "x86[_-]64"
+	    if [ $? != 0 ]; then
+		local _cputype=i686
+	    fi
 	fi
     fi
 

--- a/rustup.sh
+++ b/rustup.sh
@@ -374,7 +374,7 @@ handle_command_line_args() {
     # OK, time to do the things
     local _succeeded=true
     if [ "$_uninstall" = false ]; then
-	update_toolchain "$_toolchain" "$_prefix" "$_save" "$_update_hash_file"
+	install_toolchain_from_dist "$_toolchain" "$_prefix" "$_save" "$_update_hash_file"
 	if [ $? != 0 ]; then
 	    _succeeded=false
 	fi
@@ -438,25 +438,6 @@ validate_date() {
 }
 
 # Updating toolchains
-
-# Returns 0 on success, 1 on error
-update_toolchain() {
-    local _toolchain="$1"
-    local _prefix="$2"
-    local _save="$3"
-    local _update_hash_file="$4"
-
-    is_toolchain_installed "$_prefix"
-    local _is_installed="$RETVAL"
-
-    if [ "$_is_installed" = true ]; then
-	say "updating existing install to '$_toolchain'"
-    else
-	say "installing toolchain '$_toolchain'"
-    fi
-
-    install_toolchain_from_dist "$_toolchain" "$_prefix" "$_save" "$_update_hash_file"
-}
 
 # Returns 0 on success, 1 on error
 install_toolchain_from_dist() {
@@ -580,20 +561,6 @@ remove_toolchain() {
 	say "no toolchain installed at '$_prefix'"
     fi
 }
-
-is_toolchain_installed() {
-    local _prefix="$1"
-
-    verbose_say "looking for installed toolchain '$_toolchain'"
-
-    if [ -e "$_prefix/lib/rustlib" ]; then
-	RETVAL=true
-	return
-    fi
-
-    RETVAL=false
-}
-
 
 # Manifest interface
 

--- a/rustup.sh
+++ b/rustup.sh
@@ -23,6 +23,24 @@
 # This doesn't use -e because it makes it hard to control the
 # presentation of and response to errors.
 #
+# `set -u` is on, which means undefined variables are errors.
+# Generally when evaluating a variable that may not exist I'll
+# write `${mystery_variable-}`, which results in "" if the name
+# is undefined.
+#
+# Every command should be expected to return 0 on success, and
+# non-zero on failure. In one case, for `download_and_check`, the
+# error code needs to be interpreted more carefully because there are
+# multiple successful return codes. Additional return values may be
+# passed the `$RETVAL` global or further `RETVAL_FOO` globals as
+# needed.
+#
+# Most commands are executed via wrappers that provide extra diagnostics
+# and error handling: `run`, which prints the command on failure, and
+# returns the error code, `ignore` which does the same, but is used
+# to indicate the error code won't be handled, and `ensure`, which
+# prints the command on failure, and also exits the process.
+#
 # Pass errors on on: `run cmd arg1 arg2 || return 1`. `run` will run
 # the command, printing it if it fails; the `|| return 1` passes the
 # error on to the caller. `ensure cmd arg1 arg1`, runs the command,
@@ -32,14 +50,11 @@
 #
 # This code is very careful never to create empty paths. Any time a
 # new string that will be used as a path is produced, it is checked
-# with `assert_nz`.
+# with `assert_nz`. Likewise, pretty much any time a string is
+# constructed via command invocation it needs to be tested against
+# the empty string.
 #
 # Temporary files must be carefully deleted on every error path.
-#
-# `set -u` is on, which means undefined variables are errors.
-# Generally when evaluating a variable that may not exist I'll
-# write `${mystery_variable-}`, which results in "" if the name
-# is undefined.
 
 set -u # Undefined variables are errors
 

--- a/rustup.sh
+++ b/rustup.sh
@@ -883,7 +883,6 @@ check_sig() {
     local _quiet="$2"
 
     if ! command -v gpg > /dev/null 2>&1; then
-	say "gpg not found. not verifying signatures"
 	return
     fi
 

--- a/rustup.sh
+++ b/rustup.sh
@@ -977,7 +977,7 @@ download_and_check() {
     # If the user already has this rev then don't redownload it
     if [ -n "$_update_hash_file" ]; then
 	# NB: May fail if file does not exist
-	local _update_hash="$(cat "$_update_hash_file")"
+	local _update_hash="$(cat "$_update_hash_file" 2> /dev/null)"
 
 	verbose_say "provided update hash: $_update_hash"
 	verbose_say "new update hash: $_cache_name"

--- a/rustup.sh
+++ b/rustup.sh
@@ -226,8 +226,8 @@ initialize_metadata() {
 	local _current_version="$(cat "$version_file")"
 	verbose_say "got metadata version $_current_version"
 	if [ "$_current_version" != "$metadata_version" ]; then
-	    # Wipe the out of date metadata
-	    say "rustup metadata is out of date. deleting."
+	    # Wipe the out of date metadata.
+	    say "metadata is out of date. deleting."
 	    rm -R "$rustup_dir"
 	    need_ok "failed to remove $rustup_dir"
 	    mkdir -p "$rustup_dir"

--- a/rustup.sh
+++ b/rustup.sh
@@ -206,7 +206,7 @@ initialize_metadata() {
 	if [ "$_current_version" != "$metadata_version" ]; then
 	    # Wipe the out of date metadata
 	    say "rustup metadata is out of date. deleting."
-	    rm -Rf "$rustup_dir"
+	    rm -R "$rustup_dir"
 	    need_ok "failed to remove $rustup_dir"
 	    mkdir -p "$rustup_dir"
 	    need_ok "failed to create $rustup_dir"

--- a/rustup.sh
+++ b/rustup.sh
@@ -1093,6 +1093,7 @@ Options:
 
      --channel=(stable|beta|release)   Install from channel (default beta)
      --date=<YYYY-MM-DD>               Install from archives
+     --revision=<version-number>       Install a specific release
      --prefix=<path>                   Install to a specific location (default /usr/local)
      --uninstall                       Uninstall instead of install
      --save                            Save downloads for future reuse

--- a/rustup.sh
+++ b/rustup.sh
@@ -19,6 +19,7 @@
 set -u # Undefined variables are errors
 
 main() {
+    assert_cmds
     set_globals
     handle_command_line_args "$@"
 }
@@ -1163,27 +1164,28 @@ assert_nz() {
     if [ -z "$1" ]; then err "assert_nz $2"; fi
 }
 
-# Ensure various commands exist
-need_cmd dirname
-need_cmd basename
-need_cmd mkdir
-need_cmd cat
-need_cmd curl
-need_cmd mktemp
-need_cmd rm
-need_cmd egrep
-need_cmd grep
-need_cmd file
-need_cmd uname
-need_cmd tar
-need_cmd sed
-need_cmd sh
-need_cmd mv
-need_cmd awk
-need_cmd cut
-need_cmd sort
-need_cmd date
-need_cmd head
-need_cmd printf
+assert_cmds() {
+    need_cmd dirname
+    need_cmd basename
+    need_cmd mkdir
+    need_cmd cat
+    need_cmd curl
+    need_cmd mktemp
+    need_cmd rm
+    need_cmd egrep
+    need_cmd grep
+    need_cmd file
+    need_cmd uname
+    need_cmd tar
+    need_cmd sed
+    need_cmd sh
+    need_cmd mv
+    need_cmd awk
+    need_cmd cut
+    need_cmd sort
+    need_cmd date
+    need_cmd head
+    need_cmd printf
+}
 
 main "$@"

--- a/rustup.sh
+++ b/rustup.sh
@@ -374,8 +374,7 @@ handle_command_line_args() {
     # This will not happen if we hit certain hard errors earlier.
     if [ "$_preserve_rustup_dir" = false ]; then
 	verbose_say "removing rustup home $rustup_dir"
-	rm -R "$rustup_dir"
-	# Ignore errors
+	ensure rm -R "$rustup_dir"
     else
 	verbose_say "leaving rustup home $rustup_dir"
     fi
@@ -497,12 +496,11 @@ install_toolchain_from_dist() {
 
     install_toolchain "$_toolchain" "$_installer_file" "$_workdir" "$_prefix"
     if [ $? != 0 ]; then
-	# Ignore errors
 	say_err "failed to install toolchain"
 	_failing=true
     fi
 
-    rm -R "$_workdir"
+    run rm -R "$_workdir"
     if [ $? != 0 ]; then
 	say_err "couldn't delete workdir"
 	_failing=true
@@ -532,7 +530,7 @@ install_toolchain() {
     local _installer_dir="$_workdir/$(basename "$_installer" | sed s/.tar.gz$//)"
 
     # Extract the toolchain
-    tar xzf "$_installer" -C "$_workdir"
+    run tar xzf "$_installer" -C "$_workdir"
     if [ $? != 0 ]; then
 	verbose_say "failed to extract installer"
 	return 1
@@ -543,7 +541,7 @@ install_toolchain() {
     verbose_say "installing toolchain to '$_toolchain_dir'"
     say "installing toolchain for '$_toolchain'"
 
-    sh "$_installer_dir/install.sh" --prefix="$_toolchain_dir" --disable-ldconfig
+    run sh "$_installer_dir/install.sh" --prefix="$_toolchain_dir" --disable-ldconfig
     if [ $? != 0 ]; then
 	verbose_say "failed to install toolchain"
 	return 1

--- a/rustup.sh
+++ b/rustup.sh
@@ -224,6 +224,7 @@ initialize_metadata() {
 	need_ok "failed to write metadata version"
     else
 	local _current_version="$(cat "$version_file")"
+	need_ok "failed to load metadata version"
 	verbose_say "got metadata version $_current_version"
 	if [ "$_current_version" != "$metadata_version" ]; then
 	    # Wipe the out of date metadata.

--- a/rustup.sh
+++ b/rustup.sh
@@ -710,8 +710,10 @@ extract_channel_and_date_from_toolchain() {
 	nightly-20[0-9][0-9]-[0-9][0-9]-[0-9][0-9] | \
 	beta-20[0-9][0-9]-[0-9][0-9]-[0-9][0-9] | \
 	stable-20[0-9][0-9]-[0-9][0-9]-[0-9][0-9] )
-	    local _channel="$(echo "$_toolchain" | cut -d- -f1)"
-	    local _date="$(echo "$_toolchain" | cut -d- -f2,3,4)"
+	    local _channel="$(ensure echo "$_toolchain" | ensure cut -d- -f1)"
+	    assert_nz "$_channel" "channel"
+	    local _date="$(ensure echo "$_toolchain" | ensure cut -d- -f2,3,4)"
+	    assert_nz "$_date" "date"
 	    RETVAL_CHANNEL="$_channel"
 	    RETVAL_DATE="$_date"
 	    ;;

--- a/rustup.sh
+++ b/rustup.sh
@@ -978,7 +978,7 @@ download_and_check() {
 
 	if [ "$_cache_name" = "$_update_hash" ]; then
 	    run rm -R "$_workdir" || return 1
-	    # NB: Return code 2 is successful here!
+	    # NB: Return code 20 is successful here!
 	    return 20
 	else
 	    # Write the update hash to file

--- a/rustup.sh
+++ b/rustup.sh
@@ -725,12 +725,6 @@ extract_channel_and_date_from_toolchain() {
     esac
 }
 
-get_local_rust_manifest_name() {
-    local _toolchain="$1"
-
-    RETVAL="$manifests_dir/channel-rust-$_toolchain"
-}
-
 # Tools
 
 # FIXME: Temp names based on pid need to worry about pid recycling

--- a/rustup.sh
+++ b/rustup.sh
@@ -684,7 +684,7 @@ get_remote_installer_location_from_manifest() {
 		    ;;
 
 		nightly-* | beta-* | stable-* )
-		    extract_channel_and_date_from_toolchain "$_toolchain"
+		    extract_channel_and_date_from_toolchain "$_toolchain" || return 1
 		    local _channel="$RETVAL_CHANNEL"
 		    local _date="$RETVAL_DATE"
 		    assert_nz "$_channel" "channel"

--- a/test.sh
+++ b/test.sh
@@ -794,6 +794,21 @@ install_from_spec() {
 }
 runtest install_from_spec
 
+update_hash_file() {
+    try rustup.sh --prefix="$TEST_PREFIX" --spec=nightly --update-hash-file="$TMP_DIR/update-hash"
+    expect_output_ok "'nightly' is already up to date" rustup.sh --prefix="$TEST_PREFIX" --spec=nightly --update-hash-file="$TMP_DIR/update-hash"
+}
+runtest update_hash_file
+
+update_hash_file2() {
+    set_current_dist_date 2015-01-01
+    try rustup.sh --prefix="$TEST_PREFIX" --spec=nightly --update-hash-file="$TMP_DIR/update-hash"
+    # Since the date changed, there's an update, and we should *not* see the short-circuit
+    set_current_dist_date 2015-01-02
+    expect_not_output_ok "'nightly' is already up to date" rustup.sh --prefix="$TEST_PREFIX" --spec=nightly --update-hash-file="$TMP_DIR/update-hash"
+}
+runtest update_hash_file2
+
 echo
 echo "SUCCESS"
 echo

--- a/test.sh
+++ b/test.sh
@@ -696,7 +696,7 @@ runtest save_with_date
 out_of_date_metadata() {
     try rustup.sh --prefix="$TEST_PREFIX" --save
     echo "bogus" > "$RUSTUP_HOME/rustup-version"
-    expect_output_ok "rustup metadata is out of date" rustup.sh --prefix="$TEST_PREFIX" --save
+    expect_output_ok "metadata is out of date" rustup.sh --prefix="$TEST_PREFIX" --save
 }
 runtest out_of_date_metadata
 

--- a/test.sh
+++ b/test.sh
@@ -784,6 +784,16 @@ save_and_no_save() {
 }
 runtest save_and_no_save
 
+install_from_spec() {
+    try rustup.sh --prefix="$TEST_PREFIX" --spec=nightly
+    expect_output_ok "hash-nightly-2" "$TEST_PREFIX/bin/rustc" --version
+    try rustup.sh --prefix="$TEST_PREFIX" --spec=nightly-2015-01-01
+    expect_output_ok "hash-nightly-1" "$TEST_PREFIX/bin/rustc" --version
+    try rustup.sh --prefix="$TEST_PREFIX" --spec=1.0.0
+    expect_output_ok "hash-stable-1" "$TEST_PREFIX/bin/rustc" --version
+}
+runtest install_from_spec
+
 echo
 echo "SUCCESS"
 echo

--- a/test.sh
+++ b/test.sh
@@ -771,6 +771,19 @@ explicit_version_with_date() {
 }
 runtest explicit_version_with_date
 
+save_and_no_save() {
+    # Run with --save to create the rustup directory, and save the downloaded installer
+    try rustup.sh --prefix="$TEST_PREFIX" --revision=1.0.0 --save
+    local _cache_dir="$(ls "$RUSTUP_HOME/dl")"
+    try test -n "$_cache_dir"
+    try test -e "$RUSTUP_HOME/dl/$_cache_dir/*.tar.gz"
+    # This time it will delete the downloaded files
+    try rustup.sh --prefix="$TEST_PREFIX" --revision=1.0.0
+    local _dirlisting="$(ls "$RUSTUP_HOME/dl")"
+    try test -z "$_dirlisting"
+}
+runtest save_and_no_save
+
 echo
 echo "SUCCESS"
 echo


### PR DESCRIPTION
Sorry this is really messy. This does three primary things
- Makes `--save` work by adding a content-addressed cache to the `download_and_check` method.
- Adds a `--spec=<toolchain-spec>` that accepts a multirust-compatible 'toolchain spec', which is what rustup uses internally to identify toolchains already. It can be used instead of the `--channel`, `--date`, and `--revision` flags. Multirust uses this.
- Adds an `--update-hash-file=<file>` flag, which stores the previously-mentioned content hash in a file that con be reused later to short-circuit reinstalls if the release channel hasn't changed. Used by multirust.
- Adds lots more defensive error handling. Nearly every call is wrapped by some sort of diagnostic-reporting command runner, like `run`, `ignore`, and `ensure`. Added some comments about how the error handling works.

r? @alexcrichton
