### PR TITLE
Make rustup.sh interactive and not require sudo

### DIFF
--- a/rustup.sh
+++ b/rustup.sh
@@ -502,10 +502,24 @@ print_welcome_message() {
     local _uninstall="$2"
     local _disable_sudo="$3"
 
-    if [ "$_uninstall" = false ]; then
-	cat <<EOF
+    cat <<EOF
 
 Welcome to Rust.
+EOF
+
+    if [ "$_disable_sudo" = false ]; then
+	if [ "$(id -u)" = 0 ]; then
+	    cat <<EOF
+
+WARNING: This script appears to be running as root. While it will work
+correctly, it is no longer necessary for rustup.sh to run as root.
+EOF
+	fi
+    fi
+
+    
+    if [ "$_uninstall" = false ]; then
+	cat <<EOF
 
 This script will download the Rust compiler and its package manager, Cargo, and
 install them to $_prefix. You may install elsewhere by running this script
@@ -1408,6 +1422,7 @@ assert_cmds() {
     need_cmd head
     need_cmd printf
     need_cmd touch
+    need_cmd id
 }
 
 main "$@"

--- a/rustup.sh
+++ b/rustup.sh
@@ -271,6 +271,7 @@ handle_command_line_args() {
     local _spec=""
     local _update_hash_file=""
     local _disable_ldconfig=false
+    local _disable_sudo=false
 
     for arg in "$@"; do
 	case "$arg" in
@@ -291,6 +292,10 @@ handle_command_line_args() {
 
 	    --disable-ldconfig)
 		_disable_ldconfig=true
+		;;
+
+	    --disable-sudo)
+		_disable_sudo=true
 		;;
 
 	    -y | --yes)
@@ -1182,6 +1187,7 @@ Options:
      --prefix=<path>                   Install to a specific location (default /usr/local)
      --uninstall                       Uninstall instead of install
      --disable-ldconfig                Do not run ldconfig on Linux
+     --disable-sudo                    Do not run installer or ldconfig under sudo
      --save                            Save downloads for future reuse
 '
 }

--- a/rustup.sh
+++ b/rustup.sh
@@ -536,7 +536,7 @@ EOF
 	cat <<EOF
 
 The installer will run under 'sudo' and may ask you for your password. If you do
-not want the script to run 'sudo' then pass this script the --disable-sudo flag.
+not want the script to run 'sudo' then pass it the --disable-sudo flag.
 EOF
     fi
 


### PR DESCRIPTION
This changes rustup in the following ways.
- rustup runs 'sudo' to do the install unless --disable-sudo is passed
- it displays an initial welcome message that explains what is going to happen, including running sudo, then requires confirmation to proceed
- the -y flag disables the welcome message
- adds some ugly metadata upgrade code to deal with old root-owned .rustup directories
- warns if running as root

The basic welcome message looks like this:

```
Welcome to Rust.

This script will download the Rust compiler and its package manager, Cargo, and
install them to /usr/local. You may install elsewhere by running this script
with the --prefix=<path> option.

The installer will run under 'sudo' and may ask you for your password. If you do
not want the script to run 'sudo' then pass this script the --disable-sudo flag.

You may uninstall later by running /usr/local/lib/rustlib/uninstall.sh,
or by running this script again with the --uninstall flag.

Continue? (y/N)
```
