### PR TITLE
Make missing command error clearer

### DIFF
--- a/rustup.sh
+++ b/rustup.sh
@@ -1353,7 +1353,7 @@ err() {
 
 need_cmd() {
     if ! command -v "$1" > /dev/null 2>&1
-    then err "need $1"
+    then err "need '$1' (command not found)"
     fi
 }
 


### PR DESCRIPTION
I tried installing rust on a fresh linux install and was confused by what the hell `rustup: need file` meant.
