### PR TITLE
Handle $SHELL being set but not an absolute path.

### DIFF
--- a/rustup.sh
+++ b/rustup.sh
@@ -1017,7 +1017,7 @@ get_architecture() {
 	if [ ! -e "$_bin_to_probe" -a -e "/usr/bin/env" ]; then
 	    _bin_to_probe="/usr/bin/env"
 	fi
-	if [ -n "$_bin_to_probe" ]; then
+	if [ -e "$_bin_to_probe" ]; then
 	    file -L "$_bin_to_probe" | grep -q "x86[_-]64"
 	    if [ $? != 0 ]; then
 		local _cputype=i686

--- a/rustup.sh
+++ b/rustup.sh
@@ -1014,7 +1014,7 @@ get_architecture() {
 	# if configure is running in an interactive bash shell. /usr/bin/env
 	# exists *everywhere*.
 	local _bin_to_probe="$SHELL"
-	if [ -z "$_bin_to_probe" -a -e "/usr/bin/env" ]; then
+	if [ ! -e "$_bin_to_probe" -a -e "/usr/bin/env" ]; then
 	    _bin_to_probe="/usr/bin/env"
 	fi
 	if [ -n "$_bin_to_probe" ]; then


### PR DESCRIPTION
On Dash run from zsh on Debian, $SHELL can be just 'sh' which causes the
platform to be incorrectly assumed to be i686 even when it's actually
64-bit.
