### PR TITLE
Remove mention of prefix env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,6 @@ Install nightly archives.
 rustup.sh --channel=nightly --date=2015-04-09
 ```
 
-Install to a prefix by setting the environment.
-
-```
-RUSTUP_PREFIX=my/install/dir rustup.sh
-```
-
 Install explicit versions.
 
 ```


### PR DESCRIPTION
The 'right' way with --prefix is covered above, and this option isn't what is supposed to be used.

r? @brson 
