### PR TITLE
Add Windows/MSYS arch detection

### DIFF
--- a/rustup.sh
+++ b/rustup.sh
@@ -975,7 +975,7 @@ get_architecture() {
 	    ;;
 
 	MINGW* | MSYS*)
-	    err "unimplemented windows arch detection"
+	    local _ostype=pc-windows-gnu
 	    ;;
 
 	*)


### PR DESCRIPTION
Hi, I took steps to get multirust working under MSYS and this was one of the changes I needed to make.

It's not complete, there are some MSYS path handling problems with relation to calling `gpg` to verify signatures that I need to investigate.

I'm not sure what the stance is on MSYS support but I wanted to open this to discussion.
