### PR TITLE
Using custom downloader #39

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ Install explicit versions.
 rustup.sh --revision=1.0.0-beta
 ```
 
+Using custom downloader
+
+```
+export RUSTUP_DOWNLOADER="aria2c -c -j 10 -x 10 -s 10 --min-split-size=1M --connect-timeout=600 --timeout=600 -m0" 
+export RUSTUP_DOWNLOADER="axel -n 5 --alternate" 
+```
+
 ## Future work
 
 * GC old temp and cache files.

--- a/rustup.sh
+++ b/rustup.sh
@@ -1242,11 +1242,11 @@ download_file_and_sig() {
     fi
 
     verbose_say "downloading '$_remote_name' to '$_local_name'"
-    # Invoke curl in a way that will resume if necessary
+    # Invoke downloader in a way that will resume if necessary
     if [ "$_quiet" = false ]; then
-	(run cd "$_local_dirname" && run curl -# -C - -f -O "$_remote_name")
+	(run cd "$_local_dirname" && run_downloader "$_remote_name" "$_quiet")
     else
-	(run cd "$_local_dirname" && run curl -s -C - -f -O "$_remote_name")
+	(run cd "$_local_dirname" && run_downloader "$_remote_name" "$_quiet")
     fi
     if [ $? != 0 ]; then
 	say_err "couldn't download '$_remote_name'"
@@ -1424,6 +1424,26 @@ assert_cmds() {
     need_cmd printf
     need_cmd touch
     need_cmd id
+}
+
+run_downloader() {
+    local download_from_url=$1
+    local _quiet=$2
+
+    if [ "$_quiet" = false ]; then
+        default_download_exe="curl -# -C - -f -O"
+    else
+        default_download_exe="curl -s -C - -f -O"
+    fi
+
+    download_exe=${RUSTUP_DOWNLOADER-$default_download_exe}
+
+    echo $download_from_url|grep -q -- "^http"
+    if [ $? -eq 0 ]; then
+        run $download_exe $download_from_url
+    else
+        run $default_download_exe $download_from_url
+    fi
 }
 
 main "$@"


### PR DESCRIPTION
curl is a single thread downloader, sometime it is so slow.
I think using a custom downloader environment is good idea!
For example:

```
$export RUSTUP_DOWNLOADER="axel -n 5 --alternate" 
$multirust update nightly
```
