### PR TITLE
SHELL may be not a binary

### DIFF
--- a/rustup.sh
+++ b/rustup.sh
@@ -1017,6 +1017,13 @@ get_architecture() {
 	if [ ! -e "$_bin_to_probe" -a -e "/usr/bin/env" ]; then
 	    _bin_to_probe="/usr/bin/env"
 	fi
+	# $SHELL may be not a binary
+	if [ -e "$_bin_to_probe" ]; then
+	    file -L "$_bin_to_probe" | grep -q "text"
+	    if [ $? == 0 ]; then
+		_bin_to_probe="/usr/bin/env"
+	    fi
+	fi
 	if [ -e "$_bin_to_probe" ]; then
 	    file -L "$_bin_to_probe" | grep -q "x86[_-]64"
 	    if [ $? != 0 ]; then


### PR DESCRIPTION
I have same issue after update rust via rustup.sh - https://github.com/rust-lang/rust/issues/31150

This is my solution  - _bin_to_probe must be a binary

My shell is [xonsh](http://xon.sh/)

```
:~/p/rustup master → file -L $SHELL
/bin/xonsh: a /usr/bin/python script, ASCII text executable
```

Where binary output

```
:~/p/rustup master → file -L /usr/bin/env
/usr/bin/env: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, BuildID[sha1]=b8680bbafebe4209c51dde6dc9385a23aef6c62a, stripped
```

Without fix rustup.sh output

```
:~/p/rustup master → curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly

Welcome to Rust.

This script will download the Rust compiler and its package manager, Cargo, and
install them to /usr/local. You may install elsewhere by running this script
with the --prefix=<path> option.

The installer will run under 'sudo' and may ask you for your password. If you do
not want the script to run 'sudo' then pass it the --disable-sudo flag.

You may uninstall later by running /usr/local/lib/rustlib/uninstall.sh,
or by running this script again with the --uninstall flag.

Continue? (y/N) y

rustup: gpg available. signatures will be verified
rustup: downloading manifest for 'nightly'
rustup: downloading toolchain for 'nightly'
######################################################################## 100.0%
gpg: assuming signed data in '/home/user/.rustup/dl/0cadbf1270e1c607628a/rust-nightly-i686-unknown-linux-gnu.tar.gz'
gpg: Signature made Mon 07 Mar 2016 02:25:04 PM MSK using RSA key ID 7B3B09DC
gpg: Good signature from "Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 108F 6620 5EAE B0AA A8DD  5E1C 85AB 96E6 FA1B E5FE
     Subkey fingerprint: C134 66B7 E169 A085 1886  3216 5CB4 A934 7B3B 09DC
rustup: extracting installer
rustup: installing toolchain for 'nightly'
install: uninstalling component 'rustc'
install: uninstalling component 'rust-std-i686-unknown-linux-gnu'
install: uninstalling component 'rust-docs'
install: uninstalling component 'cargo'
install: creating uninstall script at /usr/local/lib/rustlib/uninstall.sh
install: installing component 'rustc'
install: installing component 'rust-std-i686-unknown-linux-gnu'
install: installing component 'rust-docs'
install: installing component 'cargo'

    Rust is ready to roll.
```

With my fix

```
:~/p/rustup master → ./rustup.sh --channel=nightly

Welcome to Rust.

This script will download the Rust compiler and its package manager, Cargo, and
install them to /usr/local. You may install elsewhere by running this script
with the --prefix=<path> option.

The installer will run under 'sudo' and may ask you for your password. If you do
not want the script to run 'sudo' then pass it the --disable-sudo flag.

You may uninstall later by running /usr/local/lib/rustlib/uninstall.sh,
or by running this script again with the --uninstall flag.

Continue? (y/N) y

rustup: gpg available. signatures will be verified
rustup: downloading manifest for 'nightly'
rustup: downloading toolchain for 'nightly'
######################################################################## 100.0%
gpg: assuming signed data in '/home/user/.rustup/dl/8b85f2612137ef9b1e48/rust-nightly-x86_64-unknown-linux-gnu.tar.gz'
gpg: Signature made Mon 07 Mar 2016 02:25:12 PM MSK using RSA key ID 7B3B09DC
gpg: Good signature from "Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 108F 6620 5EAE B0AA A8DD  5E1C 85AB 96E6 FA1B E5FE
     Subkey fingerprint: C134 66B7 E169 A085 1886  3216 5CB4 A934 7B3B 09DC
rustup: extracting installer
rustup: installing toolchain for 'nightly'
install: uninstalling component 'rustc'
install: uninstalling component 'rust-std-x86_64-unknown-linux-gnu'
install: uninstalling component 'rust-docs'
install: uninstalling component 'cargo'
install: creating uninstall script at /usr/local/lib/rustlib/uninstall.sh
install: installing component 'rustc'
install: installing component 'rust-std-x86_64-unknown-linux-gnu'
install: installing component 'rust-docs'
install: installing component 'cargo'

    Rust is ready to roll.
```
