### PR TITLE
on ARMv7 devices, install the armv7-unknown-linux-gnueabihf toolchain

### DIFF
--- a/rustup.sh
+++ b/rustup.sh
@@ -1489,8 +1489,13 @@ get_architecture() {
             local _cputype=arm
             ;;
 
-        armv7l)
+        armv6l)
             local _cputype=arm
+            local _ostype="${_ostype}eabihf"
+            ;;
+
+        armv7l)
+            local _cputype=armv7
             local _ostype="${_ostype}eabihf"
             ;;
 

--- a/test-v1.sh
+++ b/test-v1.sh
@@ -278,8 +278,13 @@ get_architecture() {
             local _cputype=arm
             ;;
 
-        armv7l)
+        armv6l)
             local _cputype=arm
+            local _ostype="${_ostype}eabihf"
+            ;;
+
+        armv7l)
+            local _cputype=armv7
             local _ostype="${_ostype}eabihf"
             ;;
 

--- a/test-v2.sh
+++ b/test-v2.sh
@@ -281,8 +281,13 @@ get_architecture() {
             local _cputype=arm
             ;;
 
-        armv7l)
+        armv6l)
             local _cputype=arm
+            local _ostype="${_ostype}eabihf"
+            ;;
+
+        armv7l)
+            local _cputype=armv7
             local _ostype="${_ostype}eabihf"
             ;;
 


### PR DESCRIPTION
instead of the arm-unknown-linux-gnueabihf one. The former is faster (like 2X) than the latter.

r? @alexcrichton
