### PR TITLE
Add aarch64 cpu type for 64-bit ARM systems

### DIFF
--- a/rustup.sh
+++ b/rustup.sh
@@ -1501,6 +1501,10 @@ get_architecture() {
             local _ostype="${_ostype}eabihf"
             ;;
 
+        aarch64)
+            local _cputype=aarch64
+            ;;
+
         x86_64 | x86-64 | x64 | amd64)
             local _cputype=x86_64
             ;;

--- a/test-v1.sh
+++ b/test-v1.sh
@@ -288,6 +288,10 @@ get_architecture() {
             local _ostype="${_ostype}eabihf"
             ;;
 
+        aarch64)
+            local _cputype=aarch64
+            ;;
+
         x86_64 | x86-64 | x64 | amd64)
             local _cputype=x86_64
             ;;

--- a/test-v2.sh
+++ b/test-v2.sh
@@ -291,6 +291,10 @@ get_architecture() {
             local _ostype="${_ostype}eabihf"
             ;;
 
+        aarch64)
+            local _cputype=aarch64
+            ;;
+
         x86_64 | x86-64 | x64 | amd64)
             local _cputype=x86_64
             ;;


### PR DESCRIPTION
Add support for ARM64 systems. It currently only works for nightly since no stable release is present.
