### PR TITLE
Recognize short form of --help; don't ignore unknown arguments

### DIFF
--- a/rustup.sh
+++ b/rustup.sh
@@ -310,9 +310,11 @@ handle_command_line_args() {
             --save )
                 _save=true
                 ;;
+
             --uninstall )
                 _uninstall=true
                 ;;
+
             -h | --help )
                 _help=true
                 ;;
@@ -335,9 +337,9 @@ handle_command_line_args() {
                 flag_yes=true
                 ;;
 
-	    --list-available-targets)
-		_list_targets=true
-		;;
+            --list-available-targets)
+                _list_targets=true
+                ;;
 
             --version)
                 echo "rustup.sh $version"
@@ -485,11 +487,11 @@ handle_command_line_args() {
 
     # --add-target is non-interactive
     if [ -n "$_add_target" ]; then
-	flag_yes=true
+        flag_yes=true
     fi
     # --list-targets is non-interactive
     if [ -n "$_list_targets" ]; then
-	flag_yes=true
+        flag_yes=true
     fi
 
     if [ "$flag_yes" = false ]; then
@@ -518,15 +520,15 @@ handle_command_line_args() {
     # OK, time to do the things
     local _succeeded=true
     if [ "$_list_targets" = true ]; then
-	list_targets "$_prefix"
-	if [ $? != 0 ]; then
-	    _succeeded=false
-	fi
+        list_targets "$_prefix"
+        if [ $? != 0 ]; then
+            _succeeded=false
+        fi
     elif [ -n "$_add_target" ]; then
-	add_target_to_install "$_prefix" "$_add_target" "$_save" "$_disable_sudo"
-	if [ $? != 0 ]; then
-	    _succeeded=false
-	fi
+        add_target_to_install "$_prefix" "$_add_target" "$_save" "$_disable_sudo"
+        if [ $? != 0 ]; then
+            _succeeded=false
+        fi
     elif [ "$_uninstall" = false ]; then
         install_toolchain_from_dist "$_toolchain" "$_prefix" "$_save" "$_update_hash_file" \
                                     "$_disable_ldconfig" "$_disable_sudo" "$_extra_targets"
@@ -709,8 +711,8 @@ install_toolchain_from_dist() {
         local _manifest="$RETVAL"
         assert_nz "$_manifest" "manifest"
 
-	# We'll save the manifest in the install folder for future modifications
-	_manifest_to_stash="$_manifest"
+        # We'll save the manifest in the install folder for future modifications
+        _manifest_to_stash="$_manifest"
 
         validate_manifest_v2 "$_manifest"
         if [ $? != 0 ]; then
@@ -786,7 +788,7 @@ install_toolchain_from_dist() {
     # NB: Splitting $_extra_remote_installers on space by not quoting
     local _extra_remote_installer
     for _extra_remote_installer in $_extra_remote_installers; do
-	install_extra_component "$_prefix" "$_extra_remote_installer" "$_disable_sudo" "$_save"
+        install_extra_component "$_prefix" "$_extra_remote_installer" "$_disable_sudo" "$_save"
     done
 
     # Write the update hash of the rust toolchain to file so that,
@@ -801,15 +803,15 @@ install_toolchain_from_dist() {
 
     # Install the manifest for future updates
     if [ "$_manifest_to_stash" != "" ]; then
-	# Fix for rust-lang/rust#32154. Somehow rustup.sh managed
-	# until today to exist without escaping ~ in prefix. Probably
-	# because it's only ultimately used by the install script,
-	# which is called via sh. This command here though will fail
-	# if prefix contains ~ so run it through `sh` to escape it.
-	local _prefix="$(sh -c "printf '%s' $_prefix")"
-	local _manifest_stash="$_prefix/lib/rustlib/channel-manifest.toml"
-	ensure printf "%s" "$_manifest_to_stash" | \
-	    ensure maybe_sudo "$_disable_sudo" sh -c "cat > \"$_manifest_stash\""
+        # Fix for rust-lang/rust#32154. Somehow rustup.sh managed
+        # until today to exist without escaping ~ in prefix. Probably
+        # because it's only ultimately used by the install script,
+        # which is called via sh. This command here though will fail
+        # if prefix contains ~ so run it through `sh` to escape it.
+        local _prefix="$(sh -c "printf '%s' $_prefix")"
+        local _manifest_stash="$_prefix/lib/rustlib/channel-manifest.toml"
+        ensure printf "%s" "$_manifest_to_stash" | \
+            ensure maybe_sudo "$_disable_sudo" sh -c "cat > \"$_manifest_stash\""
     fi
 }
 
@@ -836,19 +838,19 @@ merge_existing_extra_targets() {
                 ignore printf "%s" "$_extra_targets" | grep -q "$_arch"
                 if [ $? = 0 ]; then
                     verbose_say "already installing extra std component: $_arch"
-		else
-		    # See if it's the primary target
-		    ignore printf "%s" "$_primary_arch" | grep -q "$_arch"
-		    if [ $? = 0 ]; then
-			verbose_say "already installing extra std component: $_arch"
-		    else
-			verbose_say "found extra std component: $_arch"
-			_extra_targets="$_extra_targets $_arch"
-		    fi
+                else
+                    # See if it's the primary target
+                    ignore printf "%s" "$_primary_arch" | grep -q "$_arch"
+                    if [ $? = 0 ]; then
+                        verbose_say "already installing extra std component: $_arch"
+                    else
+                        verbose_say "found extra std component: $_arch"
+                        _extra_targets="$_extra_targets $_arch"
+                    fi
                 fi
-		;;
+                ;;
             *)
-		;;
+                ;;
         esac
     done < "$_components_file"
 
@@ -959,8 +961,8 @@ add_target_to_install() {
     local _manifest_file="$_prefix/lib/rustlib/channel-manifest.toml"
 
     if [ ! -e "$_manifest_file" ]; then
-	say_err "no channel manifest at '$_manifest_file'"
-	return 1
+        say_err "no channel manifest at '$_manifest_file'"
+        return 1
     fi
 
     local _manifest="$(cat "$_manifest_file")"
@@ -979,23 +981,23 @@ list_targets() {
     local _manifest_file="$_prefix/lib/rustlib/channel-manifest.toml"
 
     if [ ! -e "$_manifest_file" ]; then
-	say_err "no channel manifest at '$_manifest_file'"
-	return 1
+        say_err "no channel manifest at '$_manifest_file'"
+        return 1
     fi
 
     local _manifest="$(cat "$_manifest_file")"
 
     toml_find_package_triples  "$_manifest" rust-std
     if [ $? != 0 ]; then
-	say_err "error searching manifest for targets"
-	return 1
+        say_err "error searching manifest for targets"
+        return 1
     fi
     local _all_stds="$RETVAL"
 
     # NB: Not quoting to split on space
     local _std
     for _std in $_all_stds; do
-	printf "%s\n" "$_std"
+        printf "%s\n" "$_std"
     done
 }
 
@@ -1202,14 +1204,14 @@ toml_find_package_triples() {
     local _triples=""
     local _line
     while read _line; do
-	case "$_line" in
-	    *"[pkg.$_package.target".*"]"*)
-		verbose_say "found $_package in manifest"
-		local _triple="$(ensure printf "%s" "$_line" | ensure sed "s/.*pkg\.$_package\.target\.\(.*\)]/\1/")"
-		verbose_say "triple: $_triple"
-		_triples="$_triples $_triple"
-	    ;;
-	esac
+        case "$_line" in
+            *"[pkg.$_package.target".*"]"*)
+                verbose_say "found $_package in manifest"
+                local _triple="$(ensure printf "%s" "$_line" | ensure sed "s/.*pkg\.$_package\.target\.\(.*\)]/\1/")"
+                verbose_say "triple: $_triple"
+                _triples="$_triples $_triple"
+            ;;
+        esac
     done < "$_tmpfile"
 
     ensure rm -R "$_workdir"
@@ -1856,9 +1858,9 @@ maybe_sudo() {
 
     local _is_windows=false
     case "$_arch" in
-	*windows*)
-	    _is_windows=true
-	    ;;
+        *windows*)
+            _is_windows=true
+            ;;
     esac
 
     if [ "$_disable_sudo" = false -a "$_is_windows" = false ]; then

--- a/rustup.sh
+++ b/rustup.sh
@@ -306,7 +306,7 @@ handle_command_line_args() {
 
     local _arg
     for _arg in "$@"; do
-        case "$_arg" in
+        case "${_arg%%=*}" in
             --save )
                 _save=true
                 ;;
@@ -344,34 +344,66 @@ handle_command_line_args() {
                 exit 0
                 ;;
 
-	    *)
-		echo "Unknown argument $_arg, displaying usage:"
-		_help=true
-		;;
+            --prefix)
+                if is_value_arg "$_arg" "prefix"; then
+                    _prefix="$(get_value_arg "$_arg")"
+                fi
+                ;;
+
+            --channel)
+                if is_value_arg "$_arg" "channel"; then
+                  _channel="$(get_value_arg "$_arg")"
+                fi
+                ;;
+
+            --date)
+                if is_value_arg "$_arg" "date"; then
+                  _date="$(get_value_arg "$_arg")"
+                fi
+                ;;
+
+            --revision)
+                if is_value_arg "$_arg" "revision"; then
+                  _revision="$(get_value_arg "$_arg")"
+                fi
+                ;;
+
+            --spec)
+                if is_value_arg "$_arg" "spec"; then
+                  _spec="$(get_value_arg "$_arg")"
+                fi
+                ;;
+
+            --update-hash-file)
+                if is_value_arg "$_arg" "update-hash-file"; then
+                  # This option is used by multirust to short-circuit reinstalls
+                  # when the channel has not been updated by examining a content
+                  # hash in the update-hash-file
+                  _update_hash_file="$(get_value_arg "$_arg")"
+                fi
+                ;;
+
+            --with-target)
+                if is_value_arg "$_arg" "with-target"; then
+                  local _next_extra_target="$(get_value_arg "$_arg")"
+                  _extra_targets="$_extra_targets $_next_extra_target"
+                fi
+                ;;
+
+            --add-target)
+                if is_value_arg "$_arg" "add-target"; then
+                    _add_target="$(get_value_arg "$_arg")"
+                fi
+                ;;
+
+            *)
+                echo "Unknown argument '$_arg', displaying usage:"
+                echo ${_arg%%=*}
+                _help=true
+                ;;
 
         esac
 
-        if is_value_arg "$_arg" "prefix"; then
-            _prefix="$(get_value_arg "$_arg")"
-        elif is_value_arg "$_arg" "channel"; then
-            _channel="$(get_value_arg "$_arg")"
-        elif is_value_arg "$_arg" "date"; then
-            _date="$(get_value_arg "$_arg")"
-        elif is_value_arg "$_arg" "revision"; then
-            _revision="$(get_value_arg "$_arg")"
-        elif is_value_arg "$_arg" "spec"; then
-            _spec="$(get_value_arg "$_arg")"
-        elif is_value_arg "$_arg" "update-hash-file"; then
-            # This option is used by multirust to short-circuit reinstalls
-            # when the channel has not been updated by examining a content
-            # hash in the update-hash-file
-            _update_hash_file="$(get_value_arg "$_arg")"
-        elif is_value_arg "$_arg" "with-target"; then
-            local _next_extra_target="$(get_value_arg "$_arg")"
-            _extra_targets="$_extra_targets $_next_extra_target"
-	elif is_value_arg "$_arg" "add-target"; then
-	    _add_target="$(get_value_arg "$_arg")"
-        fi
     done
 
     if [ "$_help" = true ]; then

--- a/rustup.sh
+++ b/rustup.sh
@@ -1857,6 +1857,7 @@ Options:
      --disable-sudo                    Do not run installer under sudo
      --save                            Save downloads for future reuse
      --yes, -y                         Disable the interactive mode
+     --help, -h                        Display usage information
 '
 }
 

--- a/rustup.sh
+++ b/rustup.sh
@@ -313,7 +313,7 @@ handle_command_line_args() {
             --uninstall )
                 _uninstall=true
                 ;;
-            --help )
+            -h | --help )
                 _help=true
                 ;;
 
@@ -343,6 +343,11 @@ handle_command_line_args() {
                 echo "rustup.sh $version"
                 exit 0
                 ;;
+
+	    *)
+		echo "Unknown argument $_arg, displaying usage:"
+		_help=true
+		;;
 
         esac
 


### PR DESCRIPTION
After seeing #41 I realised my `*)` was naive. 
I tried a different solution: include all arguments in the case statement, matching on prefix.
This is a bit more verbose, but I think clearer and less error-prone. (And the verbosity could be pushed into a function if need be.)
