### PR TITLE
Check sudo before any doing, but after help

### DIFF
--- a/rustup.sh
+++ b/rustup.sh
@@ -60,7 +60,6 @@ set -u # Undefined variables are errors
 
 main() {
     assert_cmds
-    assert_root
     set_globals
     handle_command_line_args "$@"
 }
@@ -413,6 +412,9 @@ handle_command_line_args() {
         print_help
         exit 0
     fi
+
+    # Try to run `any` command with `sudo` to check we have enough rights
+    ensure maybe_sudo "$_disable_sudo" true
 
     # Make sure either rust256sum or shasum exists
     need_shasum_cmd
@@ -1963,13 +1965,6 @@ abs_path() {
     # and triggers 'cd' to print the path to stdout. Route `cd`'s output to /dev/null
     # for good measure.
     (unset CDPATH && cd "$_path" > /dev/null && pwd)
-}
-
-# you need to be root to use rustup.sh
-assert_root() {
-    if [ `id -u` != 0 ]; then
-        err "You need root permissions to install Rust. Please run with 'sudo'."
-    fi
 }
 
 assert_cmds() {


### PR DESCRIPTION
PR https://github.com/rust-lang/rustup.sh/pull/70 has imperfections:
1. Impossible to show `--help` if you aren't `root`
2. Impossible to install with MinGW
3. Impossible to install Rust to **home** directory if you haven't `root` rights
4. Impossible to use `sudo: false` for Travis

This PR check we can do `sudo` before any doing (if `--disable-sudo` not set).

Fixes https://github.com/rust-lang/rust/issues/36850
and better way to fix https://github.com/rust-lang/rust/issues/24052
