### PR TITLE
If root is not needed anymore, neither is `assert_root`

### DIFF
--- a/rustup.sh
+++ b/rustup.sh
@@ -60,7 +60,6 @@ set -u # Undefined variables are errors
 
 main() {
     assert_cmds
-    assert_root
     set_globals
     handle_command_line_args "$@"
 }
@@ -1965,12 +1964,6 @@ abs_path() {
     (unset CDPATH && cd "$_path" > /dev/null && pwd)
 }
 
-# you need to be root to use rustup.sh
-assert_root() {
-    if [ `id -u` != 0 ]; then
-        err "You need root permissions to install Rust. Please run with 'sudo'."
-    fi
-}
 
 assert_cmds() {
     need_cmd dirname


### PR DESCRIPTION
`assert_root` is called even before `disable_sudo` and the code makes mention of not needing `root` so the call to `assert_root` is probably meaningless.
